### PR TITLE
fix: default functionConfigurationsLocation refers to mappingTemplatesLocation

### DIFF
--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -39,7 +39,9 @@ export default function getAppSyncConfig(context, appSyncConfig) {
 
   const functionConfigurationsLocation = path.join(
     context.serverless.config.servicePath,
-    cfg.functionConfigurationsLocation || DEFAULT_MAPPING_TEMPLATE_LOCATION,
+    cfg.functionConfigurationsLocation ||
+      cfg.mappingTemplatesLocation ||
+      DEFAULT_MAPPING_TEMPLATE_LOCATION,
   );
 
   const { defaultMappingTemplates = {} } = cfg;


### PR DESCRIPTION
I fixed the behavior of `functionConfigurationsLocation`( https://github.com/serverless-appsync/serverless-appsync-simulator/pull/140 ) to be the same as the behavior in [serverless-appsync-plugin](https://github.com/sid88in/serverless-appsync-plugin).

document:
> functionConfigurationsLocation: # defaults to mappingTemplatesLocation (mapping-templates)

code:
https://github.com/sid88in/serverless-appsync-plugin/blob/master/src/get-config.js#L81-L82